### PR TITLE
Get all topics from kafka servers

### DIFF
--- a/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
+++ b/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
@@ -63,7 +63,7 @@ namespace KafkaNet
         /// <remarks>
         /// This method will ignore the cache and initiate a call to the kafka servers for all topics, updating the cache with the resulting metadata.
         /// </remarks>
-        Task<bool> RefreshAllTopicMetadata();
+        Task RefreshAllTopicMetadata();
 
         Task RefreshMissingTopicMetadata(params string[] topics);
 

--- a/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
+++ b/src/KafkaNetClient/Interfaces/IBrokerRouter.cs
@@ -34,7 +34,7 @@ namespace KafkaNet
         /// <summary>
         /// Returns Topic metadata for each topic requested.
         /// </summary>
-        /// <param name="topics">Collection of topids to request metadata for.</param>
+        /// <param name="topics">Collection of topics to request metadata for.</param>
         /// <returns>List of Topics as provided by Kafka.</returns>
         /// <remarks>The topic metadata will by default check the cache first and then request metadata from the server if it does not exist in cache.</remarks>
         List<Topic> GetTopicMetadataFromLocalCache(params string[] topics);
@@ -46,8 +46,24 @@ namespace KafkaNet
         /// <remarks>
         /// This method will initiate a call to the kafka servers and retrieve metadata for all given topics, updating the broke cache in the process.
         /// </remarks>
-
         Task<bool> RefreshTopicMetadata(params string[] topics);
+
+        /// <summary>
+        /// Returns Topic metadata for each topic.
+        /// </summary>
+        /// <returns>List of topics as provided by Kafka.</returns>
+        /// <remarks>
+        /// The topic metadata will by default check the cache.
+        /// </remarks>
+        List<Topic> GetAllTopicMetadataFromLocalCache();
+
+        /// <summary>
+        /// Force a call to the kafka servers to refresh metadata for all topics.
+        /// </summary>
+        /// <remarks>
+        /// This method will ignore the cache and initiate a call to the kafka servers for all topics, updating the cache with the resulting metadata.
+        /// </remarks>
+        Task<bool> RefreshAllTopicMetadata();
 
         Task RefreshMissingTopicMetadata(params string[] topics);
 

--- a/src/KafkaNetClient/KafkaMetadataProvider.cs
+++ b/src/KafkaNetClient/KafkaMetadataProvider.cs
@@ -39,11 +39,11 @@ namespace KafkaNet
         /// <param name="connections">The server connections to query.  Will cycle through the collection, starting at zero until a response is received.</param>
         /// <param name="topics">The collection of topics to get metadata for.</param>
         /// <returns>MetadataResponse validated to be complete.</returns>
-        public async Task<MetadataResponse> Get(IKafkaConnection[] connections, IEnumerable<string> topics)
+        public Task<MetadataResponse> Get(IKafkaConnection[] connections, IEnumerable<string> topics)
         {
             var request = new MetadataRequest { Topics = topics.ToList() };
             if (request.Topics.Count <= 0) return null;
-            return await Get(connections, request);
+            return Get(connections, request);
         }
 
         /// <summary>
@@ -51,10 +51,10 @@ namespace KafkaNet
         /// </summary>
         /// <param name="connections">The server connections to query.  Will cycle through the collection, starting at zero until a response is received.</param>
         /// <returns>MetadataResponse validated to be complete.</returns>
-        public async Task<MetadataResponse> Get(IKafkaConnection[] connections)
+        public Task<MetadataResponse> Get(IKafkaConnection[] connections)
         {
             var request = new MetadataRequest();
-            return await Get(connections, request);
+            return Get(connections, request);
         }
 
         private async Task<MetadataResponse> Get(IKafkaConnection[] connections, MetadataRequest request)

--- a/src/KafkaNetClient/KafkaMetadataProvider.cs
+++ b/src/KafkaNetClient/KafkaMetadataProvider.cs
@@ -43,6 +43,22 @@ namespace KafkaNet
         {
             var request = new MetadataRequest { Topics = topics.ToList() };
             if (request.Topics.Count <= 0) return null;
+            return await Get(connections, request);
+        }
+
+        /// <summary>
+        /// Given a collection of server connections, query for all topics metadata.
+        /// </summary>
+        /// <param name="connections">The server connections to query.  Will cycle through the collection, starting at zero until a response is received.</param>
+        /// <returns>MetadataResponse validated to be complete.</returns>
+        public async Task<MetadataResponse> Get(IKafkaConnection[] connections)
+        {
+            var request = new MetadataRequest();
+            return await Get(connections, request);
+        }
+
+        private async Task<MetadataResponse> Get(IKafkaConnection[] connections, MetadataRequest request)
+        {
             var maxRetryAttempt = 2;
             var performRetry = false;
             var retryAttempt = 0;

--- a/src/kafka-tests/Unit/KafkaMetadataProviderTests.cs
+++ b/src/kafka-tests/Unit/KafkaMetadataProviderTests.cs
@@ -81,6 +81,22 @@ namespace kafka_tests.Unit
         }
 
         [Test, Repeat(IntegrationConfig.NumberOfRepeat)]
+        public void ShouldReturnWhenNoErrorReceivedAndTopicsNotSpecified()
+        {
+            var conn = Substitute.For<IKafkaConnection>();
+
+            conn.SendAsync(Arg.Any<IKafkaRequest<MetadataResponse>>())
+                .Returns(x => CreateMetadataResponse(ErrorResponseCode.NoError));
+
+            using (var provider = new KafkaMetadataProvider(_log))
+            {
+                var response = provider.Get(new[] { conn });
+            }
+
+            conn.Received(1).SendAsync(Arg.Any<IKafkaRequest<MetadataResponse>>());
+        }
+
+        [Test, Repeat(IntegrationConfig.NumberOfRepeat)]
         [TestCase(ErrorResponseCode.Unknown)]
         [TestCase(ErrorResponseCode.RequestTimedOut)]
         [TestCase(ErrorResponseCode.InvalidMessage)]


### PR DESCRIPTION
Added ability to retrieve all topics metadata from kafka servers. 
Methods were added:
BrokerRouter.RefreshAllTopicMetadata() - force update all topics metadata from kafka servers to cache.
BrokerRouter.GetAllTopicMetadataFromLocalCache() - select all topic metadata that exists in cache.
