### PR TITLE
Fixed bug with max buffer size on FetchRequest

### DIFF
--- a/src/KafkaNetClient/Consumer.cs
+++ b/src/KafkaNetClient/Consumer.cs
@@ -121,7 +121,7 @@ namespace KafkaNet
             {
                 try
                 {
-                    var bufferSizeHighWatermark = FetchRequest.DefaultBufferSize;
+                    var bufferSizeHighWatermark = (int)(FetchRequest.DefaultBufferSize * _options.FetchBufferMultiplier);
 
                     _options.Log.DebugFormat("Consumer: Creating polling task for topic: {0} on parition: {1}", topic, partitionId);
                     while (_disposeToken.IsCancellationRequested == false)


### PR DESCRIPTION
Option FetchBufferMultiplier usage was missed. It causes an
impossibility to extend max buffer size on FetchRequest and leads to
BufferUnderRunException when you have large messages on Kafka.
