### PR TITLE
Fix bug in manual consumer regarding leader -1

### DIFF
--- a/src/KafkaNetClient/Consumer.cs
+++ b/src/KafkaNetClient/Consumer.cs
@@ -226,6 +226,17 @@ namespace KafkaNet
                             needToRefreshMetadata = true;
                             _options.Log.ErrorFormat(ex.Message);
                         }
+                        catch (NoLeaderElectedForPartition ex)
+                        {
+                            needToRefreshMetadata = true;
+                            _options.Log.ErrorFormat(ex.Message);
+                        }
+                        catch (LeaderNotFoundException ex)//the numbar partition of can be change
+                        {
+                            needToRefreshMetadata = true;
+                            _options.Log.ErrorFormat(ex.Message);
+                        }
+
                         catch (TaskCanceledException ex)
                         {
                             //TODO :LOG

--- a/src/KafkaNetClient/Properties/AssemblyInfo.cs
+++ b/src/KafkaNetClient/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: GuidAttribute("eb234ec0-d838-4abd-9224-479ca06f969d")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]

--- a/src/KafkaNetClient/Protocol/Protocol.cs
+++ b/src/KafkaNetClient/Protocol/Protocol.cs
@@ -224,6 +224,26 @@ namespace KafkaNet.Protocol
     }
 
     [Serializable]
+    public class NoLeaderElectedForPartition : ApplicationException
+    {
+         public NoLeaderElectedForPartition(string message, params object[] args)
+            : base(string.Format(message, args))
+        {
+        }
+
+        public NoLeaderElectedForPartition(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        public NoLeaderElectedForPartition(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+
+
+    [Serializable]
     public class BrokerException : ApplicationException
     {
         public KafkaEndpoint BrokerEndPoint;

--- a/src/kafka-tests/Fakes/BrokerRouterProxy.cs
+++ b/src/kafka-tests/Fakes/BrokerRouterProxy.cs
@@ -120,6 +120,7 @@ namespace kafka_tests
                 };
         }
 
+
         public static async Task<MetadataResponse> CreateMetadataResponseWithSingleBroker()
         {
             return new MetadataResponse
@@ -164,6 +165,49 @@ namespace kafka_tests
             };
         }
 
+        public static async Task<MetadataResponse> CreateMetadataResponseWithNotEndToElectLeader()
+        {
+            return new MetadataResponse
+            {
+                CorrelationId = 1,
+                Brokers = new List<Broker>
+                        {
+                            new Broker
+                                {
+                                    Host = "localhost",
+                                    Port = 2,
+                                    BrokerId = 1
+                                },
+                        },
+                Topics = new List<Topic>
+                        {
+                            new Topic
+                                {
+                                    ErrorCode = 0,
+                                    Name = TestTopic,
+                                    Partitions = new List<Partition>
+                                        {
+                                            new Partition
+                                                {
+                                                    ErrorCode = 0,
+                                                    Isrs = new List<int> {1},
+                                                    PartitionId = 0,
+                                                    LeaderId = -1,
+                                                    Replicas = new List<int> {1},
+                                                },
+                                            new Partition
+                                                {
+                                                    ErrorCode = 0,
+                                                    Isrs = new List<int> {1},
+                                                    PartitionId = 1,
+                                                    LeaderId = 1,
+                                                    Replicas = new List<int> {1},
+                                                }
+                                        }
+                                }
+                        }
+            };
+        }
         public static async Task<MetadataResponse> CreateMetaResponseWithException()
         {
             throw new Exception();

--- a/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
+++ b/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
@@ -195,6 +195,7 @@ namespace kafka_tests.Integration
         [TestCase(1000, 70)]
         [TestCase(30000, 550)]
         [TestCase(50000, 850)]
+        [TestCase(200000, 8050)]
         public async Task ConsumerShouldConsumeInSameOrderAsAsyncProduced_dataLoad(int numberOfMessage, int timeoutInMs)
         {
             int partition = 0;

--- a/src/kafka-tests/Unit/BrokerRouterTests.cs
+++ b/src/kafka-tests/Unit/BrokerRouterTests.cs
@@ -134,11 +134,23 @@ namespace kafka_tests.Unit
             var result1 = router.GetTopicMetadataFromLocalCache(TestTopic);
             var result2 = router.GetTopicMetadataFromLocalCache(TestTopic);
 
+            Assert.AreEqual(1, router.GetAllTopicMetadataFromLocalCache().Count);
             Assert.That(routerProxy.BrokerConn0.MetadataRequestCallCount, Is.EqualTo(1));
             Assert.That(result1.Count, Is.EqualTo(1));
             Assert.That(result1[0].Name, Is.EqualTo(TestTopic));
             Assert.That(result2.Count, Is.EqualTo(1));
             Assert.That(result2[0].Name, Is.EqualTo(TestTopic));
+        }
+
+        [Test, Repeat(IntegrationConfig.NumberOfRepeat)]
+        public async Task BrokerRouteShouldThrowNoLeaderElectedForPartition()
+        {
+            var routerProxy = new BrokerRouterProxy(_kernel);
+            routerProxy.MetadataResponse = BrokerRouterProxy.CreateMetadataResponseWithNotEndToElectLeader;
+
+            var router = routerProxy.Create();
+            Assert.Throws<NoLeaderElectedForPartition>(async () =>await router.RefreshMissingTopicMetadata(TestTopic));
+            Assert.AreEqual(0, router.GetAllTopicMetadataFromLocalCache().Count);
         }
 
         [Test, Repeat(IntegrationConfig.NumberOfRepeat)]


### PR DESCRIPTION
Kafka doc: "The node id for the kafka broker currently acting as leader for this partition. If no leader exists because we are in the middle of a leader election this id will be -1."
